### PR TITLE
Fix removal of b64 attribute of random_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  master_password      = var.password == "" ? random_id.master_password.b64 : var.password
+  master_password      = var.password == "" ? random_id.master_password.b64_std : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? aws_db_subnet_group.this[0].name : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 }


### PR DESCRIPTION
Change b64 to b64_std as the b64 attribute of random_id has been removed as it was deprecated.